### PR TITLE
Reduce the number of call to identity authenticate

### DIFF
--- a/src/interactions/__tests__/router.test.ts
+++ b/src/interactions/__tests__/router.test.ts
@@ -93,8 +93,7 @@ describe("Router", () => {
     expect(consentFollowRedirect.text).toContain(
       '<input type="hidden" name="id_token"'
     );
-    // TODO: Check why it is called 3 times!
-    expect(authenticateFn).toBeCalledTimes(3);
+    expect(authenticateFn).toBeCalledTimes(2);
   });
 
   it("should create a session with the correct accountId", async () => {
@@ -189,7 +188,7 @@ describe("Router", () => {
     expect(consentResponse.text).toContain(
       `"/interaction/${interactionId}/abort"`
     );
-    expect(authenticateFn).toBeCalledTimes(2);
+    expect(authenticateFn).toBeCalledTimes(1);
   });
 
   it("should return error when authorize return error", async () => {

--- a/src/oidcprovider/__tests__/provider.test.ts
+++ b/src/oidcprovider/__tests__/provider.test.ts
@@ -2,17 +2,15 @@ import * as O from "fp-ts/Option";
 import * as index from "../.";
 import * as records from "../../__tests__/utils/records";
 
-describe("userInfoToAccount", () => {
+describe("makeAccountClaims", () => {
   it("should map properties", async () => {
     const user = records.validIdentity;
     const expected = user;
-    const actual = index.userInfoToAccount(user);
-    const actualClaims = await actual.claims("id_token", "profile", {}, []);
+    const actual = index.makeAccountClaims(user);
 
-    expect(actual.accountId).toStrictEqual(expected.fiscalCode);
-    expect(actualClaims.sub).toStrictEqual(expected.fiscalCode);
-    expect(actualClaims.family_name).toStrictEqual(expected.familyName);
-    expect(actualClaims.given_name).toStrictEqual(expected.givenName);
+    expect(actual.sub).toStrictEqual(expected.fiscalCode);
+    expect(actual.family_name).toStrictEqual(expected.familyName);
+    expect(actual.given_name).toStrictEqual(expected.givenName);
   });
 });
 


### PR DESCRIPTION
Before this commit the Identity.authenticate was called more than
necessary.
After this commit it is called no more than two times.