### PR TITLE
Fix regression on unauthorized implicit flow

### DIFF
--- a/src/adapters/http/openidConnect/nodeOidcProvider/interactions.ts
+++ b/src/adapters/http/openidConnect/nodeOidcProvider/interactions.ts
@@ -64,12 +64,8 @@ const getInteractionHandler =
       ),
       // render the result
       TE.fold(
-        (errorMessage) =>
-          TE.tryCatch(
-            () =>
-              provider.interactionFinished(req, res, { error: errorMessage }),
-            E.toError
-          ),
+        (error) =>
+          interactionFinishedTE(provider, req, res, { error: error.kind }),
         (result) => {
           switch (result.kind) {
             case "LoginResult":


### PR DESCRIPTION
Before this commit, an implicit flow that ended with unauthorized caused
an not handled error. After this commit the regression is fixed and the
flow finish landing to the redirect uri with an unauthorized error.